### PR TITLE
Support to Erlang 19

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,6 @@
 {deps, 
   [
+   {edown, ".*", {git, "https://github.com/uwiger/edown.git", {branch, "master"}}},
    {erlware_commons, ".*", {git, "https://github.com/erlware/erlware_commons.git", {branch, "master"}}},
    {parse_trans, ".*", {git, "https://github.com/esl/parse_trans.git", {branch, "master"}}}
 ]}.

--- a/src/seresye_engine.erl
+++ b/src/seresye_engine.erl
@@ -312,6 +312,8 @@ get_records([_ | Tail], Acc) ->
     get_records(Tail, Acc).
 
 get_record_fields([], Acc) -> lists:reverse(Acc);
+get_record_fields([{typed_record_field, RecordField, _T} | Tail], Acc) ->
+    get_record_fields([RecordField | Tail], Acc);
 get_record_fields([{record_field, _,
                     {atom, _, FieldName}, {nil, _}}
                    | Tail],


### PR DESCRIPTION
Adds support to the typed_record_field tuple exposed since OTP-19. Refer to OTP-13148